### PR TITLE
Add types.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zd-once",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Zero deps, Ensure a function is only called once",
     "main": "index.js",
     "directories": {
@@ -27,5 +27,6 @@
         "istanbul": "^0.4.5",
         "mocha": "^5.1.1",
         "mocha-lcov-reporter": "^1.3.0"
-    }
+    },
+	"types": "./types.d.ts"
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,2 @@
+export declare function once<T extends any[], R>(fn: (...args: T) => R): (...args: T) => R | undefined;
+export declare function onceStrict<T extends any[], R>(fn: (...args: T) => R): (...args: T) => R;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,2 +1,7 @@
-export declare function once<T extends any[], R>(fn: (...args: T) => R): (...args: T) => R | undefined;
-export declare function onceStrict<T extends any[], R>(fn: (...args: T) => R): (...args: T) => R;
+export declare function once<T extends (...args: any[]) => any>(
+  fn: T
+): (...args: Parameters<T>) => ReturnType<T> | undefined;
+
+export declare function onceStrict<T extends (...args: any[]) => any>(
+  fn: T
+): (...args: Parameters<T>) => ReturnType<T>;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,6 +1,6 @@
 export declare function once<T extends (...args: any[]) => any>(
   fn: T
-): (...args: Parameters<T>) => ReturnType<T> | undefined;
+): (...args: Parameters<T>) => ReturnType<T>;
 
 export declare function onceStrict<T extends (...args: any[]) => any>(
   fn: T


### PR DESCRIPTION
This PR introduces TypeScript type definitions for the `once` and `onceStrict` functions.

The use of any (`T extends any[]`) is intentional and limited to representing “any array of arguments” — the implementer is responsible for passing a well-typed function.

This ensures maximum flexibility while leaving type strictness and argument validation to the function being passed in.